### PR TITLE
php-cs-fixer 2.16.1 is minimum for PHP 7.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.16.*",
+        "friendsofphp/php-cs-fixer": "~2.16.1",
         "phpunit/phpunit" : "^7"
     },
     "config" : {


### PR DESCRIPTION
Make sure that 2.16.0 is not accidentally used (e.g. if something tries to `composer update --prefer-lowest`