### PR TITLE
Update infrastructure like done in vobject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,17 +5,4 @@ composer.lock
 # Tests
 tests/cov/
 tests/.phpunit.result.cache
-
-# Composer binaries
-bin/phpunit
-bin/php-cs-fixer
-bin/phpstan
-bin/phpstan.phar
-
-# Vim
-.*.swp
-
-# IDEs
-/.idea
-
 .php_cs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,10 @@ php:
 matrix:
   fast_finish: true
 
-install:
-  - composer require --dev phpstan/phpstan:^0.12
-
 before_script:
   - composer install
 
 script:
-  - ./bin/php-cs-fixer fix lib/ --dry-run --diff
-  - ./bin/phpstan.phar analyse -c phpstan.neon lib
-  - ./bin/phpunit --configuration tests/phpunit.xml
+  - php vendor/bin/php-cs-fixer fix --dry-run --diff
+  - php vendor/bin/phpstan.phar analyse -c phpstan.neon lib tests
+  - php vendor/bin/phpunit --configuration tests/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,23 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.16.1",
+        "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7 || ^8"
     },
-    "config" : {
-        "bin-dir" : "bin/"
+    "scripts": {
+        "phpstan": [
+            "@php vendor/bin/phpstan analyse lib tests"
+        ],
+        "cs-fixer": [
+            "@php vendor/bin/php-cs-fixer fix"
+        ],
+        "phpunit": [
+            "@php vendor/bin/phpunit --configuration tests/phpunit.xml"
+        ],
+        "test": [
+            "composer phpstan",
+            "composer cs-fixer",
+            "composer phpunit"
+        ]
     }
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -6,7 +6,6 @@
   convertWarningsToExceptions="true"
   beStrictAboutTestsThatDoNotTestAnything="true"
   beStrictAboutOutputDuringTests="true"
-  enforceTimeLimit="true"
   >
   <testsuites>
     <testsuite name="sabre-skel">


### PR DESCRIPTION
- remove the `bin-dir` definition in `composer.json`
- remove the `bin` stuff from `.gitignore` because it is no longer needed
- remove IDE-specific stuff from `.gitignore` (people can put that sort of thing in their own `.gitignore_global` https://help.github.com/en/github/using-git/ignoring-files#create-a-global-gitignore ) 
- add `phpstsn` to `composer.json` and cleanup special `phpstan` code from `.travis.yml`
- run `php-cs-fixer` on the whole project, not just `lib`
- add a `scripts` section to `composer.json` so that developers can type `composer test` and it will run all the tests.
- remove `enforceTimeLimit` from `phpunit.xml` - trying to use that results in:
```
Error:         Package phpunit/php-invoker is required for enforcing time limits
```
IMO it is not worth bothering to add `php-invoker` ...

This update `skel` to be an example of how this test/CI... infrastructure is put together.

Most changes are taken from the recent changes in https://github.com/sabre-io/vobject/pull/496