### PR TITLE
Run phpstan only once in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,27 @@ php:
   - 7.3
   - 7.4
 
+env:
+  global:
+    - RUN_PHPSTAN="FALSE"
+  matrix:
+    - PREFER_LOWEST="" WITH_COVERAGE="--coverage-clover=coverage.xml"
+    - PREFER_LOWEST="--prefer-lowest" $WITH_COVERAGE=""
+
 matrix:
+  include:
+    - name: 'PHPStan'
+      php: 7.4
+      env: RUN_PHPSTAN="TRUE"
   fast_finish: true
 
 before_script:
-  - composer install
+  - composer update --prefer-source $PREFER_LOWEST
 
 script:
-  - php vendor/bin/php-cs-fixer fix --dry-run --diff
-  - php vendor/bin/phpstan.phar analyse -c phpstan.neon lib tests
-  - php vendor/bin/phpunit --configuration tests/phpunit.xml
+  - if [ $RUN_PHPSTAN == "FALSE"  ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
+  - if [ $RUN_PHPSTAN == "FALSE"  ]; then php vendor/bin/phpunit --configuration tests/phpunit.xml $WITH_COVERAGE; fi
+  - if [ $RUN_PHPSTAN == "TRUE"  ]; then php vendor/bin/phpstan analyse -c phpstan.neon lib tests; fi
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Maybe this style of `.travis.yml` should be the standard?
It runs `phpstan` only once, and runs `phpunit` with/without `composer --prefer-lowest`
Taken partly from what is in `sabre-io/http`
