### PR TITLE
Do not do full composer dev install for phpstan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ matrix:
   fast_finish: true
 
 before_script:
-  - composer update --prefer-source $PREFER_LOWEST
+  - if [ $RUN_PHPSTAN == "FALSE" ]; then composer update --prefer-source $PREFER_LOWEST; fi
+  - if [ $RUN_PHPSTAN == "TRUE" ]; then composer install --no-dev; fi
+  - if [ $RUN_PHPSTAN == "TRUE" ]; then composer update phpstan/phpstan; fi
 
 script:
   - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi


### PR DESCRIPTION
See if this is any use.

The `phpstan` Travis job is installing all the dev dependencies, but actually most of them (dependencies for `php-cs-fixer` and `phpunit`) are not needed. It just wastes time fetching a heap of things.