### PR TITLE
Use at least current phpunit minor versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.16.1",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit" : "^7 || ^8"
+        "phpunit/phpunit" : "^7.5 || ^8.5"
     },
     "scripts": {
         "phpstan": [


### PR DESCRIPTION
When we do the `--prefer-lowest` thing in CI, it is currently trying to run `phpunit` with `7.0.0`

That fails in some repos, when the test code tries to use newer assertions like `assertIsArray()` which only became available from some 7.* minor release.

IMO there is no advantage in knowing that the unit tests pass with `phpunit`  7.0.0. We are happy to know that they pass with some reasonably-new 7.*
