### PR TITLE
Do not --prefer-source with composer update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - composer update --prefer-source $PREFER_LOWEST
+  - composer update $PREFER_LOWEST
 
 script:
   - if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi


### PR DESCRIPTION
For some reason this caused `phpunit` to run less tests in `sabre-io/dav`
https://github.com/sabre-io/dav/pull/1240#issuecomment-581506167

Note: made PRs to the other repos and they all "work" (the number of unit tests run does not change)

@staabm do you have any idea why `--prefer-source` was specified?