### PR TITLE
Use latest php-cs-fixer 2.17.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.16.7",
+        "friendsofphp/php-cs-fixer": "~2.17.1",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit" : "^7.5 || ^8.5 || ^9.0"
     },


### PR DESCRIPTION
The latest php-cs-fixer finds some new things. Code changes were needed in https://github.com/sabre-io/dav/pull/1316 for `sabre/dav`. We might as well consistently make sure to use at least this version 2.17.1 in all repos so that we are doing consistent code-style checking.
